### PR TITLE
Viewer fixes

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -1,6 +1,7 @@
 import sys
 import pygame
 import pygame.locals
+import pygame.time
 pygame.init()
 size = width, height = 575, 575
 
@@ -50,7 +51,7 @@ import struct
 
 
 data = open('Resources/video.bin', 'rb')
-import time
+clock = pygame.time.Clock()
 while True:
     for event in pygame.event.get():
         if event.type == pygame.locals.QUIT:
@@ -72,4 +73,4 @@ while True:
             screen.blit(label, pos)
 
     pygame.display.update()
-    time.sleep(0.05)
+    clock.tick(20)

--- a/viewer.py
+++ b/viewer.py
@@ -1,4 +1,6 @@
+import sys
 import pygame
+import pygame.locals
 pygame.init()
 size = width, height = 575, 575
 
@@ -52,6 +54,10 @@ import struct
 data = open('Resources/video.bin', 'rb')
 import time
 while True:
+    for event in pygame.event.get():
+        if event.type == pygame.locals.QUIT:
+            sys.exit(0)
+
     for k, v in positions.items():
         x, y = v
         pos = get_screen_pos(x, y)

--- a/viewer.py
+++ b/viewer.py
@@ -30,8 +30,6 @@ for strip_pair in range(5):
 
 positions = {i: v for i, v in enumerate(pos_list)}
 
-red = (255, 0, 0)
-
 def get_color(i):
     red = 255 * (i / 199.0)
     green = 0

--- a/viewer.py
+++ b/viewer.py
@@ -49,7 +49,7 @@ myfont = pygame.font.SysFont("monospace", 15)
 import struct
 
 
-data = open('video.bin', 'rb')
+data = open('Resources/video.bin', 'rb')
 import time
 while True:
     for k, v in positions.items():

--- a/viewer.py
+++ b/viewer.py
@@ -66,7 +66,7 @@ while True:
         b = ord(data.read(1))
         color = (r,g,b)
 
-        pygame.draw.circle(screen, color, pos, 10)
+        pygame.draw.circle(screen, color, pos, 17)
 
         if label_lights:
             label = myfont.render(str(k), 1, (255, 255, 255))


### PR DESCRIPTION
Change the default input file path to match the output of LightRender.py.  Respect the close button and exit when it's clicked.  Fix the frame rate to be no faster than 20 FPS.  Display larger circles, to more closely model our desired diffusion effects.  Add a sample file that shows the mandelbrot fractal.
